### PR TITLE
Fix accessory check to work in studio

### DIFF
--- a/src/AmazingNewAccessoryLogic/AmazingNewAccessoryLogic/ANAL.CharacterController.cs
+++ b/src/AmazingNewAccessoryLogic/AmazingNewAccessoryLogic/ANAL.CharacterController.cs
@@ -257,7 +257,7 @@ namespace AmazingNewAccessoryLogic
 
             if (AmazingNewAccessoryLogic.Debug.Value)
                 AmazingNewAccessoryLogic.Logger.LogInfo($"Acc in slot {slot + 1} changed kind!");
-            if (forceRemove || AccessoriesApi.GetCvsAccessory(slot).ddAcsType.value == 0)
+            if (forceRemove || ChaControl.objAccessory[slot] == null)
             {
                 if (AmazingNewAccessoryLogic.Debug.Value) AmazingNewAccessoryLogic.Logger.LogInfo($"Removing...");
                 int outfit = ChaControl.fileStatus.coordinateType;


### PR DESCRIPTION
With Pseudo Maker this check breaks a some stuff because `GetCvsAccessory` only works in maker. Checking the accessory object list on the `ChaControl` for null values is the same as the accessory type being 0 (type 0 = no accessory = no object)