### PR TITLE
Fix for Studio Accessories on scene load

### DIFF
--- a/src/AmazingNewAccessoryLogic/AmazingNewAccessoryLogic/ANAL.CharacterController.cs
+++ b/src/AmazingNewAccessoryLogic/AmazingNewAccessoryLogic/ANAL.CharacterController.cs
@@ -1253,18 +1253,15 @@ namespace AmazingNewAccessoryLogic
 
                 IEnumerator UpdateLater()
                 {
-                    if((!StudioAPI.InsideStudio)
+                    for (int i = 0; i < 2; i++) yield return null;
+                    if (lastCoordHadANAL && !StudioAPI.InsideStudio)
                     {
-                        for (int i = 0; i < 2; i++) yield return null;
-                        if (lastCoordHadANAL)
-                        {
-                            if (AmazingNewAccessoryLogic.Debug.Value)
-                                AmazingNewAccessoryLogic.Logger.LogInfo("Resetting accessories!");
-                            lastCoordHadANAL = false;
-                            for (int i = 0; i < ChaControl.infoAccessory.Length; i++)
-                                if (ChaControl.infoAccessory[i] != null)
-                                    setAccessoryState(i, true);
-                        }
+                        if (AmazingNewAccessoryLogic.Debug.Value)
+                            AmazingNewAccessoryLogic.Logger.LogInfo("Resetting accessories!");
+                        lastCoordHadANAL = false;
+                        for (int i = 0; i < ChaControl.infoAccessory.Length; i++)
+                            if (ChaControl.infoAccessory[i] != null)
+                                setAccessoryState(i, true);
                     }
                     lfg?.ForceUpdate();
                 }

--- a/src/AmazingNewAccessoryLogic/AmazingNewAccessoryLogic/ANAL.CharacterController.cs
+++ b/src/AmazingNewAccessoryLogic/AmazingNewAccessoryLogic/ANAL.CharacterController.cs
@@ -1253,15 +1253,18 @@ namespace AmazingNewAccessoryLogic
 
                 IEnumerator UpdateLater()
                 {
-                    for (int i = 0; i < 2; i++) yield return null;
-                    if (lastCoordHadANAL)
+                    if((!StudioAPI.InsideStudio)
                     {
-                        if (AmazingNewAccessoryLogic.Debug.Value)
-                            AmazingNewAccessoryLogic.Logger.LogInfo("Resetting accessories!");
-                        lastCoordHadANAL = false;
-                        for (int i = 0; i < ChaControl.infoAccessory.Length; i++)
-                            if (ChaControl.infoAccessory[i] != null)
-                                setAccessoryState(i, true);
+                        for (int i = 0; i < 2; i++) yield return null;
+                        if (lastCoordHadANAL)
+                        {
+                            if (AmazingNewAccessoryLogic.Debug.Value)
+                                AmazingNewAccessoryLogic.Logger.LogInfo("Resetting accessories!");
+                            lastCoordHadANAL = false;
+                            for (int i = 0; i < ChaControl.infoAccessory.Length; i++)
+                                if (ChaControl.infoAccessory[i] != null)
+                                    setAccessoryState(i, true);
+                        }
                     }
                     lfg?.ForceUpdate();
                 }


### PR DESCRIPTION
This should prevent accessories from being set to always active on when a scene is loaded even when an accessory state was set to off when saving a scene